### PR TITLE
devel/binutils: Unbreak build on Darwin

### DIFF
--- a/devel/binutils/Makefile
+++ b/devel/binutils/Makefile
@@ -47,7 +47,7 @@ INSTALLATION_DIRS=	${PKGGNUDIR}bin ${PKGGNUDIR}${PKGMANDIR}/man1
 #
 # Supported utils and libraries differ quite a bit across platforms.
 #
-PLIST_VARS+=	ctf gas gold gprof ld
+PLIST_VARS+=	ctf gas gold gprof ld ldint
 
 .include "../../mk/bsd.prefs.mk"
 
@@ -62,6 +62,7 @@ PLIST.ctf=		yes
 
 .if ${OPSYS} != "Darwin"
 PLIST.gas=	yes
+PLIST.ldint=	yes
 .endif
 
 .if ${OPSYS} != "IRIX" && ${OPSYS} != "AIX" && ${OPSYS} != "Darwin"

--- a/devel/binutils/PLIST.common
+++ b/devel/binutils/PLIST.common
@@ -81,7 +81,7 @@ info/binutils.info
 ${PLIST.ctf}info/ctf-spec.info
 ${PLIST.gprof}info/gprof.info
 ${PLIST.gld}info/ld.info
-info/ldint.info
+${PLIST.ldint}info/ldint.info
 info/sframe-spec.info
 ${PLIST.gld}lib/bfd-plugins/libdep.so
 lib/libbfd.la


### PR DESCRIPTION
Configure on Darwin does not create ldint.info
Patch PLIST_VARS to disable on Darwin